### PR TITLE
Add payment terms to purchase_order_templates.xml

### DIFF
--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -43,6 +43,10 @@
                     <strong>Order Deadline:</strong>
                     <p t-field="o.date_order" class="m-0"/>
                 </div>
+                <div class="col-3 bm-2">
+                  <strong>Payment Terms:</strong>
+                  <p t-field="o.payment_term_id" class="m-0"/>
+                </div>
             </div>
 
             <table class="table table-sm o_main_table table-borderless mt-4">


### PR DESCRIPTION
Pull request:

Description of the issue/feature this PR addresses:
- Default purchase order document does not include payment terms 

Current behavior before PR:
- Default purchase order document does not show payment terms 

Desired behavior after PR is merged:
- Payment terms are shown in document header


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
